### PR TITLE
Add environment banner and rename production to live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,10 @@
 .env
 .env.local
 .env.development
-.env.production
+.env.live
 .env.development.local
 .env.test.local
-.env.production.local
+.env.live.local
 /.vscode/*
 !/.vscode/extensions.json
 .idea

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Copy the example and fill in your values:
 
 ```bash
 cp .env.example .env.development
-cp .env.example .env.production
+cp .env.example .env.live
 ```
 
 Required variables:
@@ -28,7 +28,7 @@ Required variables:
 | `VITE_DEBUG` | Set to `true` to log analytics to console instead of remote server |
 
 - `.env.development` is loaded during `yarn dev`
-- `.env.production` is loaded during `yarn build`
+- `.env.live` is loaded during `yarn build`
 
 ## Development
 
@@ -55,7 +55,7 @@ yarn build
 yarn preview
 ```
 
-In production, `VITE_DATA_URL` should point directly to the data server (e.g. `https://nfa-admin.foodmedcenter.org/file-by-filename`).
+In live, `VITE_DATA_URL` should point directly to the data server (e.g. `https://nfa-admin.foodmedcenter.org/file-by-filename`).
 
 ## Internationalization
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview",
+    "build": "tsc && vite build --mode live",
+    "preview": "vite preview --mode live",
     "test.e2e": "cypress run",
     "test.unit": "vitest",
     "lint": "eslint"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,6 +209,32 @@ const GeocoderModal: React.FC<{
   </IonModal>;
 }
 
+const ENV_MODE = import.meta.env.MODE;
+if (ENV_MODE === 'live') {
+  console.log('Environment: live');
+}
+
+const EnvironmentBanner = () => {
+  if (ENV_MODE === 'live') return null;
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      zIndex: 99999,
+      background: '#ff9800',
+      color: 'white',
+      textAlign: 'center',
+      fontSize: '12px',
+      padding: '2px 0',
+      fontWeight: 'bold',
+    }}>
+      {ENV_MODE.toUpperCase()}
+    </div>
+  );
+};
+
 export const App = () => {
   const {t, i18n} = useTranslation();
 
@@ -330,6 +356,7 @@ export const App = () => {
   ], [staticLayers, foodPantries, soupKitchens, t]);
 
   return <IonApp>
+    <EnvironmentBanner />
     <IonPage>
       <IonContent>
 	<div style={{height: '100vh', width: '100vw'}}>


### PR DESCRIPTION
## Summary
- Add orange top banner showing environment name (e.g. "DEVELOPMENT") in non-live modes
- In live mode, no banner — just a `console.log("Environment: live")`
- Rename `.env.production` to `.env.live`
- Update build/preview scripts to use `--mode live`
- Update all code, gitignore, and README references from "production" to "live"

## Test plan
- [ ] `yarn dev` — orange "DEVELOPMENT" banner at top
- [ ] `yarn build && yarn preview` — no banner, "Environment: live" in console
- [ ] `.env.live` is loaded during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)