### PR TITLE
Simplify .gitignore for env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,8 @@
 
 # misc
 .DS_Store
-.env
-.env.local
-.env.development
-.env.live
-.env.development.local
-.env.test.local
-.env.live.local
+.env*
+!.env.example
 /.vscode/*
 !/.vscode/extensions.json
 .idea


### PR DESCRIPTION
## Summary
- Replace individual `.env.*` entries with `.env*` glob + `!.env.example` exception
- Automatically covers any future environments (staging, live, etc.) without updating .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)