### PR TITLE
Add flags to language dropdown, WCAG-compliant label

### DIFF
--- a/src/map/Geocoder.tsx
+++ b/src/map/Geocoder.tsx
@@ -14,9 +14,10 @@ interface GeocoderProps {
   };
   onGeocode: (results: google.maps.GeocoderResult[]) => void;
   helperText?: string;
+  language?: string;
 }
 
-export function Geocoder({apiKey, components, onGeocode, helperText}: GeocoderProps) {
+export function Geocoder({apiKey, components, onGeocode, helperText, language}: GeocoderProps) {
   const {isLoaded} = useJsApiLoader({
     googleMapsApiKey: apiKey,
     libraries: LIBRARIES,
@@ -36,15 +37,20 @@ export function Geocoder({apiKey, components, onGeocode, helperText}: GeocoderPr
       componentRestrictions.locality = components.locality;
     }
 
+    const request: google.maps.GeocoderRequest = {address, componentRestrictions};
+    if (language) {
+      request.language = language;
+    }
+
     geocoder.geocode(
-      {address, componentRestrictions},
+      request,
       (results, status) => {
         if (status === 'OK' && results && results.length > 0) {
           onGeocode(results);
         }
       },
     );
-  }, [components, onGeocode]);
+  }, [components, onGeocode, language]);
 
   const {t} = useTranslation();
 

--- a/src/map/LanguageSelector.tsx
+++ b/src/map/LanguageSelector.tsx
@@ -3,10 +3,10 @@ import {useTranslation} from 'react-i18next';
 import {useMap} from './MapContext';
 
 const languages = [
-  {code: 'en', label: 'English'},
-  {code: 'es', label: 'Español'},
-  {code: 'ko', label: '한국어'},
-  {code: 'id', label: 'Bahasa Indonesia'},
+  {code: 'en', label: 'English', flag: '🇺🇸'},
+  {code: 'es', label: 'Español', flag: '🇪🇸'},
+  {code: 'ko', label: '한국어', flag: '🇰🇷'},
+  {code: 'id', label: 'Bahasa Indonesia', flag: '🇮🇩'},
 ];
 
 export function LanguageSelector() {
@@ -14,22 +14,24 @@ export function LanguageSelector() {
   const {setClickedFeatures} = useMap();
 
   return (
-    <IonSelect
-      label={t('language')}
-      labelPlacement="stacked"
-      value={i18n.language}
-      onIonChange={(e) => {
-        i18n.changeLanguage(e.detail.value);
-        setClickedFeatures([]);
-      }}
-      interface="popover"
-      style={{marginBottom: '32px'}}
-    >
-      {languages.map((lang) => (
-        <IonSelectOption key={lang.code} value={lang.code}>
-          {lang.label}
-        </IonSelectOption>
-      ))}
-    </IonSelect>
+    <>
+      <p id='language-selector-label' style={{marginBottom: '4px'}}>{t('language')}</p>
+      <IonSelect
+        aria-labelledby='language-selector-label'
+        value={i18n.language}
+        onIonChange={(e) => {
+          i18n.changeLanguage(e.detail.value);
+          setClickedFeatures([]);
+        }}
+        interface="popover"
+        style={{marginBottom: '32px'}}
+      >
+        {languages.map((lang) => (
+          <IonSelectOption key={lang.code} value={lang.code}>
+            {lang.flag} {lang.label}
+          </IonSelectOption>
+        ))}
+      </IonSelect>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Add flag emoji next to each language option (🇺🇸 🇪🇸 🇰🇷 🇮🇩)
- Move "Language" label out of IonSelect into a plain \`<p>\` element, wired up via \`aria-labelledby\` for WCAG compliance
- Geocoder now accepts an optional \`language\` prop (not currently used — kept in English for log consistency)

## Test plan
- [ ] Flags appear next to each language in the dropdown
- [ ] "Language" label still shows above the dropdown
- [ ] Screen reader announces "Language, combobox" when focused on the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)