### PR TITLE
Translate static cpds/mms layers for the 8 new languages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,18 +47,39 @@ import {
 import './App.scss';
 
 import mms_en from './data/mms.json';
+import mms_ar from './data/mms.ar.json';
+import mms_bn from './data/mms.bn.json';
 import mms_es from './data/mms.es.json';
+import mms_fr from './data/mms.fr.json';
 import mms_ko from './data/mms.ko.json';
+import mms_pl from './data/mms.pl.json';
+import mms_ru from './data/mms.ru.json';
+import mms_ur from './data/mms.ur.json';
+import mms_zhHans from './data/mms.zh-Hans.json';
+import mms_zhHant from './data/mms.zh-Hant.json';
 import mm_truck from './data/mm_truck.svg';
 import cpds_en from './data/cpds.json';
+import cpds_ar from './data/cpds.ar.json';
+import cpds_bn from './data/cpds.bn.json';
 import cpds_es from './data/cpds.es.json';
+import cpds_fr from './data/cpds.fr.json';
 import cpds_ko from './data/cpds.ko.json';
+import cpds_pl from './data/cpds.pl.json';
+import cpds_ru from './data/cpds.ru.json';
+import cpds_ur from './data/cpds.ur.json';
+import cpds_zhHans from './data/cpds.zh-Hans.json';
+import cpds_zhHant from './data/cpds.zh-Hant.json';
 
 // Static per-language layer data. Anything not in this map falls back to English
-// at the read sites below (`|| mmsByLang.en`). Add more languages here as we
-// translate the static GeoJSON.
-const mmsByLang: Record<string, any> = {en: mms_en, es: mms_es, ko: mms_ko};
-const cpdsByLang: Record<string, any> = {en: cpds_en, es: cpds_es, ko: cpds_ko};
+// at the read sites below (`|| mmsByLang.en`).
+const mmsByLang: Record<string, any> = {
+  en: mms_en, ar: mms_ar, bn: mms_bn, es: mms_es, fr: mms_fr, ko: mms_ko,
+  pl: mms_pl, ru: mms_ru, ur: mms_ur, 'zh-Hans': mms_zhHans, 'zh-Hant': mms_zhHant,
+};
+const cpdsByLang: Record<string, any> = {
+  en: cpds_en, ar: cpds_ar, bn: cpds_bn, es: cpds_es, fr: cpds_fr, ko: cpds_ko,
+  pl: cpds_pl, ru: cpds_ru, ur: cpds_ur, 'zh-Hans': cpds_zhHans, 'zh-Hant': cpds_zhHant,
+};
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';

--- a/src/data/cpds.ar.json
+++ b/src/data/cpds.ar.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "الثلاثاء الأول فقط من كل شهر"
+          }
+        ],
+        "notes": "- شريك مجتمعي - مركز إيبيتس الميداني بين الأجيال\n- تشرين الأول/أكتوبر 2015"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الثلاثاء الثاني والرابع من كل شهر"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - صندوق النهر\n- تم افتتاحه في آب/أغسطس 2016"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - مستوطنة الشوارع الكبرى\n-افتتح في كانون الثاني/يناير 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - الجمعية العالمية للمرأة\n-فتحت أبريل 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الخميس الأول والثالث من كل شهر"
+          }
+        ],
+        "notes": "- الشراكة المجتمعية - الرابطة الأساسية للصحة\n-مفتوح في حزيران 2018\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الجمعة الرابعة فقط من كل شهر"
+          }
+        ],
+        "notes": "- الشراكة المجتمعية - الرابطة الأساسية للصحة\n-مفتوح تشرين الأول/أكتوبر 2018\n-هذا موقع توزيع مباشر."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "الجمعة الأولى والثالثة من كل شهر"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - جيش الخلاص\n-فتحت تشرين الثاني/نوفمبر 2018"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الثلاثاء الثاني والرابع من كل شهر"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - الكنيسة المعمدانية للزمالات\n-مفتوح في أيار/مايو 2019"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الخميس الثاني والرابع من كل شهر"
+          }
+        ],
+        "notes": "- شريك مجتمعي - مركز لنكولن سكوير للأحياء ومراهقون للعدالة الغذائية"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- شريك مجتمعي - برنامج توزيع الأغذية على أسرة المسيح\n-مفتوح في أيلول/سبتمبر 2019"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الاثنين الثاني والرابع فقط من كل شهر"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - دوريس ماكلولين - شقق المحيطات\n- تم افتتاحه في آذار/مارس 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "الثلاثاء الأول والثالث من كل شهر"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - الرابطة المقيمة لأبراج بولو الأرض\n- تم افتتاحه في تموز/يوليه 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - كنيسة برونكس الشمالية\n- مفتوحة في آب/أغسطس 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- الشريك المجتمعي - نادي فتيات ماديسون سكوير\n- تم افتتاحه في أيلول/سبتمبر 2020\n- يرجى الاتصال (718) 733-5500 لمزيد من المعلومات"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "الخميس الثاني والرابع من كل شهر"
+          }
+        ],
+        "notes": "- الشريك المجتمعي - مجلس دوغلاس المقيم\n- تم افتتاحه في أيلول/سبتمبر 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- الشريك المجتمعي - نادي فتيات ماديسون سكوير\n-مفتوح في حزيران/يونيه 2021\n- يرجى الاتصال (718) 462-6100 لمزيد من المعلومات"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الأربعاء الثالث فقط من كل شهر"
+          }
+        ],
+        "notes": "- شراكة مجتمعية - مؤسسة ميسرة ذات صلة\n-مفتوح في أيلول/سبتمبر 2021"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "الخميس الأول والثالث من كل شهر"
+          }
+        ],
+        "notes": "-شريك مجتمعي - كل شخص يأكل شركة SI Inc.\n-فتحت في تموز/يوليه 2022"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.bn.json
+++ b/src/data/cpds.bn.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে শুধুমাত্র প্রথম মঙ্গলবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - ইবস ফিল্ড ইন্টারপ্রজেক্ট সেন্টার\n- অক্টোবর ২০১৫"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে মাত্র ২ ও ৪ মঙ্গলবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - নদী তহবিল\n- ২০১৬ সালের ফেব্রুয়ারি মাসে খোলা"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টিনার – গ্র্যান্ড স্ট্রিট কনফিউজমেন্ট\n- জানুয়ারির ১ তারিখে খোলা"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টিনার – ওয়াইওয়াসি\n- খোলা এপ্রিল ২০১৭"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে শুধুমাত্র ১ম ও ৩য় বৃহস্পতিবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার – স্বাস্থ্যের প্রয়োজনীয় এসোসিয়েশন\n- জুন ২০১৮ খোলা হয়েছে\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে চতুর্থ শুক্রবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার – স্বাস্থ্যের প্রয়োজনীয় এসোসিয়েশন\n- অক্টোবর ২০১৮ খোলা হয়েছে\n- এটা সরাসরি বিতরণ এলাকা."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "প্রতি মাসের ১ম ও ৩য় শুক্রবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - ত্রাণ বাহিনী\n- নভেম্বর ২০১৮ খোলা হয়েছে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে মাত্র ২ ও ৪ মঙ্গলবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - সহকর্মী ব্যাপ্টিস্ট চার্চ\n- খোলা হয়েছিল মে ২০,১৯"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে শুধুমাত্র ২ ও ৪ম বৃহস্পতিবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার- লিঙ্কনড স্কয়ারিং সেন্টার এবং খাদ্য ন্যায় বিচার কেন্দ্র"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার- খ্রিস্টের খাদ্য বিতরণ কার্যক্রমের পরিবার\n- সেপ্টেম্বরের ২০ তারিখে খোলা"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে মাত্র ২ ও ৪তম সোমবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - ডোরিস ম্যাক ম্যাক্লিন - ইনসাইডিং (এনওয়াইসিএ)\n- মার্চ ২০২০ খোলা হয়েছে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "প্রতি মাসে মাত্র ১ম ও ৩য় মঙ্গলবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টিনার – পোলো গ্রাউন্ড টাওয়ারস অধিবাসীদের সংগঠন (এনওয়াইসিএ)\n- জুলাই ২০"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - নর্থ ব্রঙ্ক্স এসডি চার্চ\n- আগস্ট ২০২০ খোলা হয়েছে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- কমিউনিটি পার্টনার- ম্যাডিসন স্কোয়ার বয়েজ এবং মেয়েদের ক্লাব\n- সেপ্টেম্বর ২০\n- আরও তথ্যের জন্য ৭৩-৫৫০০ ডলার"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "প্রতি মাসে শুধুমাত্র ২ ও ৪ম বৃহস্পতিবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টিনার- ডগলাস হাউসস অধিবাসীদের কাউন্সিল\n- সেপ্টেম্বর ২০"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- কমিউনিটি পার্টনার- ম্যাডিসন স্কোয়ার বয়েজ এবং মেয়েদের ক্লাব\n- জুন ২০২১ খোলা হয়েছে\n- আরও তথ্যের জন্য দয়া করে (৭১৮) ৪৬-৬১০০ নম্বর কল করুন"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে মাত্র ৩ দিন"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - Affফোর্ড ফাউন্ডেশন সম্পর্কিত।\n- সেপ্টেম্বর ২০,২১"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "প্রতি মাসে শুধুমাত্র ১ম ও ৩য় বৃহস্পতিবার"
+          }
+        ],
+        "notes": "- কমিউনিটি পার্টনার - সবাই SIL খায়,\n- ২০২২ সালের মধ্যে খোলা হয়েছিল"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.fr.json
+++ b/src/data/cpds.fr.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "Un seul mardi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Centre intergénérationnel Ebbets Field\n- Ouvert en octobre 2015"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "2ème et 4ème mardis de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Fonds River\n- Ouverture août 2016"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Établissement de Grand Street\n- Ouvert en janvier 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- Partenaire communautaire – YWCA\n- Ouvert en avril 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "1er et 3ème jeudi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Health Essential Association\n- Ouvert en juin 2018\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "4ème vendredi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Health Essential Association\n- Ouverture octobre 2018\n- C'est un site de distribution directe."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "1er et 3e vendredi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Armée du salut\n- Ouvert en novembre 2018"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "2ème et 4ème mardis de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Fellowship Baptist Church\n- Ouvert en mai 2019"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "2ème et 4ème jeudis de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Lincoln Square Neighborhood Center et adolescents pour la justice alimentaire"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Programme de distribution des aliments de la famille du Christ\n- Ouvert en septembre 2019"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "2ème et 4ème lundi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Doris McLaughlin - Oceanside Apartments (NYCHA)\n- Ouverture mars 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "1er et 3ème mardi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Association résidente des tours Polo Grounds (NYCHA)\n- Ouverture en juillet 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Église SDA North Bronx\n- Ouverture août 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- Partenaire communautaire – Madison Square Boys & Girls Club\n- Ouvert en septembre 2020\n- S'il vous plaît appelez (718) 733-5500 pour plus d'informations"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "2ème et 4ème jeudis de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Conseil résident des maisons Douglas\n- Ouvert en septembre 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- Partenaire communautaire – Madison Square Boys & Girls Club\n- Ouvert en juin 2021\n- S'il vous plaît appelez (718) 462-6100 pour plus d'informations"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "3ème mercredi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Fondation affordable\n- Ouvert en septembre 2021"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "1er et 3ème jeudi de chaque mois"
+          }
+        ],
+        "notes": "- Partenaire communautaire – Everyone Eats SI Inc.,\n- Ouvert en juillet 2022"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.pl.json
+++ b/src/data/cpds.pl.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko pierwszy wtorek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Centrum Międzypokoleniowe Ebbets Field\n- Otwarty październik 2015"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko drugi i czwarty wtorek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Fundusz Rzeczny\n- Otwarty sierpień 2016"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Grand Street Settlement\n- Otwarty styczeń 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- Partner wspólnotowy - YWCA\n- Otwarty kwiecień 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko pierwszy i trzeci czwartek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Stowarzyszenie Esencjalne Zdrowia\n- Otwarty czerwiec 2018\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko czwarty piątek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Stowarzyszenie Esencjalne Zdrowia\n- Otwarty październik 2018\n- To jest bezpośrednie miejsce dystrybucji."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "Tylko pierwszy i trzeci piątek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner społeczny - Armia Zbawienia\n- Otwarty listopad 2018"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko drugi i czwarty wtorek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Kościół Baptystów\n- Otwarty maj 2019 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko drugi i czwarty czwartek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner społeczny - Centrum Sąsiedztwa na Placu Lincolna i Nastolatki na rzecz Sprawiedliwości Żywności"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Rodzina Chrystusa Program dystrybucji żywności\n- Otwarty wrzesień 2019 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko drugi i czwarty poniedziałek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Doris McLaughlin - Apartamenty Oceanside (NYCHA)\n- Otwarty marzec 2020 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "Tylko pierwszy i trzeci wtorek każdego miesiąca"
+          }
+        ],
+        "notes": "- Community Partner - Polo Grounds Towers Resident Association (NYCHA)\n- Otwarty lipiec 2020 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Kościół Północnego Bronksu SDA\n- Otwarty sierpień 2020 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- Partner społeczny - Madison Square Boys & Girls Club\n- Otwarty wrzesień 2020 r.\n- Proszę zadzwonić (718) 733- 5500 aby uzyskać więcej informacji"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "Tylko drugi i czwarty czwartek każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner wspólnotowy - Douglass Houses Resident Council\n- Otwarty wrzesień 2020 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- Partner społeczny - Madison Square Boys & Girls Club\n- Otwarty czerwiec 2021\n- Proszę zadzwonić (718) 462-6100 aby uzyskać więcej informacji"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko 3. środa każdego miesiąca"
+          }
+        ],
+        "notes": "- Partner Wspólnoty - Powiązana Fundacja Przystępna\n- Otwarty wrzesień 2021 r"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Tylko pierwszy i trzeci czwartek każdego miesiąca"
+          }
+        ],
+        "notes": "- Community Partner - Everyone Eats SI Inc.,\n- Otwarty lipiec 2022"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.ru.json
+++ b/src/data/cpds.ru.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только первый вторник каждого месяца"
+          }
+        ],
+        "notes": "- Сообщество-партнер - Центр Эббетс Филд\n- Открыт в октябре 2015 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 2-й и 4-й вторник каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества – Фонд реки\n- Открыт в августе 2016 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "Сообщество-партнер - Grand Street Settlement\n- Открыт в январе 2017 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "Партнер сообщества - YWCA\n- Открыт в апреле 2017 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 1-й и 3-й четверг каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества - Ассоциация по вопросам здравоохранения\n- Открыт в июне 2018 года\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 4-я пятница каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества - Ассоциация по вопросам здравоохранения\n- Открыт в октябре 2018 года\nЭто сайт прямого распространения."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "Только 1-я и 3-я пятница каждого месяца"
+          }
+        ],
+        "notes": "Сообщество-партнер Армия спасения\n- Открыт в ноябре 2018 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 2-й и 4-й вторник каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества - Баптистская церковь\n- Открыт в мае 2019 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 2-й и 4-й четверг каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества - Центр соседства Линкольн-сквер и подростки за продовольственную справедливость"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "Партнер сообщества – Программа распределения продуктов питания «Семья Христа»\n- Открыт в сентябре 2019 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 2-й и 4-й понедельник каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества - Дорис Маклафлин - Апартаменты Oceanside (NYCHA)\n- Открыт в марте 2020 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "Только 1-й и 3-й вторник каждого месяца"
+          }
+        ],
+        "notes": "Сообщество-партнер - Ассоциация жителей Поло Граундс Тауэрс (NYCHA)\n- Открыт в июле 2020 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "Партнер сообщества - Церковь SDA в Северном Бронксе\n- Открыт в августе 2020 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "Клуб мальчиков и девочек Madison Square Boys & Girls Club\n- Открыт в сентябре 2020 года\n- Пожалуйста, позвоните (718) 733-5500 для получения дополнительной информации"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "Только 2-й и 4-й четверг каждого месяца"
+          }
+        ],
+        "notes": "Сообщество Партнер - Дуглас Хаус Резидент Совет\n- Открыт в сентябре 2020 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "Клуб мальчиков и девочек Madison Square Boys & Girls Club\n- Открыт в июне 2021 года\n- Пожалуйста, позвоните (718) 462-6100 для получения дополнительной информации"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 3-я среда каждого месяца"
+          }
+        ],
+        "notes": "Партнер сообщества - Related Affordable Foundation\n- Открыт в сентябре 2021 года"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "Только 1-й и 3-й четверг каждого месяца"
+          }
+        ],
+        "notes": "Сообщество-партнер - Все едят SI Inc.\n- Открыт в июле 2022 года"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.ur.json
+++ b/src/data/cpds.ur.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کا صرف پہلا منگل"
+          }
+        ],
+        "notes": "Community Partner – ایبٹ آباد فیلڈ انٹرجنل سینٹر –\n- اوپن اکتوبر 2015"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کے صرف 2 اور 4 منگل ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کمیونٹی حصہر – دی ریور فنڈ –\n- کھلا اگست 2016ء -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "Community Partner – گرینڈ اسٹریٹ اسکیلمنٹ –\n- کھلا جنوری 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- کمیونٹی حصہر – YWCA –\n- اوپنڈ اپریل 2017"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کے صرف 1 اور 3 جمعرات ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کمیونٹی حصہر – صحت بنیادی شراکت -\n- اوپن جون 2018.\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کا صرف 4واں جمعہ"
+          }
+        ],
+        "notes": "- کمیونٹی حصہر – صحت بنیادی شراکت -\n- اوپن اکتوبر 2018ء -\n- یہ براہ راست ایک جگہ ہے."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "ہر مہینے کا صرف 1 واں اور 3واں جمعہ ہوتا ہے۔"
+          }
+        ],
+        "notes": "- کمیونٹی حصہر – نجات فوج –\n- اوپن نومبر 2018ء -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کے صرف 2 اور 4 منگل ہوتے ہیں۔"
+          }
+        ],
+        "notes": "Community Partner – ہمدرد پادری –\n- اوپنڈ مئی 2019ء -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کے صرف 2 اور 4 جمعرات ہوتے ہیں۔"
+          }
+        ],
+        "notes": "Community Partner – Lincoln Square Foreigny Center اور Jenes for Food Justice -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "Community Partner – خاندان مسیح کھانے پینے کا پروگرام\n- اوپن ستمبر 2019ء -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر ماہ کے صرف 2 اور 4 ویں منگل ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- Community Partner – ڈورس مک لاہوبلین - بحر اوقیانوس کے متبادلات (YYCHA) -\n- کھلا مارچ 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "ہر مہینے کا صرف 1 واں اور 3 ربیع الثانی ہے۔"
+          }
+        ],
+        "notes": "Community Partner – پولو گراؤنڈز وسکونسن ایسوسی ایشن (سی این ٹی اے) -\n- کھلا جولائی 2020"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "Community Partner – North Bronx SDA Church –\n- اوپننگ اگست 2020ء -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "Community Partner – Madison Square Boys & گرلز کلب -\n- اوپن ستمبر 2020ء -\n- براہ مہربانی دعوت (718) 733-5500 مزید معلومات کے لیے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "ہر مہینے کے صرف 2 اور 4 جمعرات ہوتے ہیں۔"
+          }
+        ],
+        "notes": "Community Partner – ڈگلس ہاؤسز وسکونسن کونسل –\n- اوپن ستمبر 2020ء -"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "Community Partner – Madison Square Boys & گرلز کلب -\n- کھلا جون 2021\n- براہ مہربانی دعوت (718) 462-6100 مزید معلومات کے لیے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کے صرف ۳ ویں بدھ"
+          }
+        ],
+        "notes": "Community Partner – تعلقہ آفاق فاؤنڈیشن –\n- کھلا ستمبر 2021"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "ہر مہینے کے صرف 1 اور 3 جمعرات ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کمیونٹی حصہر – ہر کوئی ایس آئی آئی کھانا کھاتا ہے،\n- کھلا جولائی 2022 -"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.zh-Hans.json
+++ b/src/data/cpds.zh-Hans.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月的第一个星期二"
+          }
+        ],
+        "notes": "- 社区伙伴-Ebbets实地代际中心\n- 2015年10月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月只有第二和第四个星期二"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 河流基金\n- 2016年8月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴-大街道定居点\n- 2017年1月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 基督教女青年会\n- 2017年4月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月的第1个星期四和第3个星期四"
+          }
+        ],
+        "notes": "- 社区伙伴-健康基本协会\n- 2018年6月开放\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月的第4个星期五"
+          }
+        ],
+        "notes": "- 社区伙伴-健康基本协会\n- 2018年10月开放\n- 这是一个直接分发网站."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "每个月的第1个和第3个星期五"
+          }
+        ],
+        "notes": "- 社区伙伴-救世军\n- 2018年11月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月的第2个星期二和第4个星期二"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 浸会联谊会\n- 2019年5月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月只有第2和第4个星期四"
+          }
+        ],
+        "notes": "- 社区伙伴-林肯广场居民区中心和青少年食品正义组织"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 基督家庭食品分配方案\n- 2019年9月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月只有第二和第四个星期一"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 多丽丝·麦克劳克林 -- -- 洋边公寓(纽约)\n- 2020年3月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "每个月的第1和3个星期二"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 波罗地塔居民协会\n- 2020年7月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴-北布朗克SDA教堂\n- 2020年8月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- 社区伙伴-麦迪逊广场男孩女孩俱乐部\n- 2020年9月开放\n- 请打电话(718)733-5500 索取更多信息"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "每个月只有第2和第4个星期四"
+          }
+        ],
+        "notes": "- 社区伙伴-道格拉斯住房居民委员会\n- 2020年9月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "- 社区伙伴-麦迪逊广场男孩女孩俱乐部\n- 2021年6月开放\n- 请打电话(718)462-6100 索取更多信息"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "每个月的第三个星期三"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 相关负担得起的基金会\n- 2021年9月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就每个月的第1和3个星期四"
+          }
+        ],
+        "notes": "- 社区伙伴-人人都吃SI公司,\n- 2022年7月开放"
+      }
+    }
+  ]
+}

--- a/src/data/cpds.zh-Hant.json
+++ b/src/data/cpds.zh-Hant.json
@@ -1,0 +1,649 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95827712883619,
+          40.66484362915894
+        ]
+      },
+      "properties": {
+        "name": "Ebbets Field Houses – Crown Heights (Brooklyn)",
+        "streetAddress": "Courtyard inside the Ebbets Field Apartment Houses - 1720 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11225",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:30:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- Ebbets地區代际中心\n- 2015年10月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.8674754435212,
+          40.66821779808902
+        ]
+      },
+      "properties": {
+        "name": "Pink Houses NYCHA – East New York (Brooklyn)",
+        "streetAddress": "Pink Houses parking lot behind 2628 Linden Blvd",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11208",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "第 二 二 四 二 二 二 二 四 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二 二"
+          }
+        ],
+        "notes": "- 社区伙伴-河流基金\n- 2016年8月開通"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.97904995701182,
+          40.716975826029675
+        ]
+      },
+      "properties": {
+        "name": "Grand Street Settlement – Lower East Side (Manhattan)",
+        "streetAddress": "72 Columbia Street",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10002",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 大街定居点\n- 2017年1月開通"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.81893674351963,
+          40.758094419882205
+        ]
+      },
+      "properties": {
+        "name": "YWCA – Flushing (Queens)",
+        "streetAddress": "42-07 Parsons Blvd.",
+        "addressLocality": "Flushing",
+        "addressRegion": "NY",
+        "postalCode": "11355",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 基督教女青年会\n- 2017年4月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.99078500119481,
+          40.5998714481062
+        ]
+      },
+      "properties": {
+        "name": "Bensonhurst – (Brooklyn)",
+        "streetAddress": "2336 86th St",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11214",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 健康基本协会\n- 2018年6月開通\n"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95597998570271,
+          40.59899914418679
+        ]
+      },
+      "properties": {
+        "name": "Sheepshead Bay – (Brooklyn)",
+        "streetAddress": "Sidewalk on E 16 St - 1602 Avenue U",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11229",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 健康基本协会\n--2018年10月通車.\n- 這是直通地點."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9060831011938,
+          40.661146680563355
+        ]
+      },
+      "properties": {
+        "name": "Brownsville – (Brooklyn)",
+        "streetAddress": "Salvation Army - Brownsville – 280 Riverdale Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11212",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Fr"
+            ],
+            "timeStart": "13:00:00",
+            "timeEnd": "15:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 救世军\n--2018年11月通車"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88871024352132,
+          40.6673365745202
+        ]
+      },
+      "properties": {
+        "name": "East New York – (Brooklyn)",
+        "streetAddress": "Fellowship Baptist Church – 509 Van Siclen Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11207",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "9:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 浸信会\n- 2019年5月開放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.98679224351926,
+          40.77457266970479
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side – (Manhattan)",
+        "streetAddress": "Sidewalk in front of Lincoln Square Neighborhood Center - 250 W 65th St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10023",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- 社区伙伴-林肯平地(Lincoln Square Neagueborhood Center and Teens for Food Justice)相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相相接相接相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.84647800119048,
+          40.842795035796264
+        ]
+      },
+      "properties": {
+        "name": "Westchester Square – (Bronx)",
+        "streetAddress": "Harvest Fields Community Church - 2626 East Tremont Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10461",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00"
+          }
+        ],
+        "notes": "- 社区伙伴 -- -- 基督家庭食品分配方案\n- 2019年9月開通"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.78485683003126,
+          40.59368835262741
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway – (Queens)",
+        "streetAddress": "Social Center – Oceanside Apartments (NYCHA) – 339 Beach 54 St",
+        "addressLocality": "Arverne",
+        "addressRegion": "NY",
+        "postalCode": "11692",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Mo"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就每個月的第二和第四個星期一了"
+          }
+        ],
+        "notes": "相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相接相相接相相接相接相接相接相接相接相接相相相接相相接相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相\n- 2020年3月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93695723002686,
+          40.832081960133344
+        ]
+      },
+      "properties": {
+        "name": "Harlem – (Manhattan)",
+        "streetAddress": "Community Center – 3005 Frederick Douglass Blvd",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10039",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Tu"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "-- -- 波羅地塔居民会(NYCHA)\n- 2020年7月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.85795173002607,
+          40.8809745537125
+        ]
+      },
+      "properties": {
+        "name": "Williamsbridge – (Bronx)",
+        "streetAddress": "North Bronx SDA Church – 3743 Bronxwood Avenue",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10469",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00"
+          }
+        ],
+        "notes": "(克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克克\n- 2020年8月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.88776680119017,
+          40.85863770036734
+        ]
+      },
+      "properties": {
+        "name": "North Bronx (Little Italy)",
+        "streetAddress": "Madison Square Boys & Girls Club – Grimm Clubhouse – 543 E 189 st",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10458",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "-相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相近;\n- 2020年9月开放\n有需要再打718通733-5500"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.96528114351888,
+          40.796437804068034
+        ]
+      },
+      "properties": {
+        "name": "Upper West Side 2 – (Manhattan)",
+        "streetAddress": "Douglass Houses NYCHA – 830 Columbus Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10025",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "12:00:00",
+            "timeEnd": "14:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "-- -- 道格拉斯住房居民会\n- 2020年9月开放"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.95548827235777,
+          40.64918511150437
+        ]
+      },
+      "properties": {
+        "name": "Flatbush (Brooklyn)",
+        "streetAddress": "Madison Square Boys & Girls Club – Thomas S. Murphy Clubhouse – 2245 Bedford Ave",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11226",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [],
+        "notes": "-相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相近;\n- 2021年6月開通\n有需要再打去462到6100取取"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.75162245886739,
+          40.59415629910103
+        ]
+      },
+      "properties": {
+        "name": "Far Rockaway 2 (Queens)",
+        "streetAddress": "Ocean Park Apartments – 125 Beach 17 street – Far Rockaway, NY 11691",
+        "addressLocality": "Far Rockaway",
+        "addressRegion": "NY",
+        "postalCode": "11691",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "We"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "- 社區伙伴 -- -- 相關可支付基金\n- 2021年9月開通"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.14401037235919,
+          40.569936970461605
+        ]
+      },
+      "properties": {
+        "name": "Staten Island Community Partner Distribution",
+        "streetAddress": "Knights of Columbus – 397 Clarke Avenue",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10306",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              "Th"
+            ],
+            "timeStart": "10:00:00",
+            "timeEnd": "12:00:00",
+            "notes": "就活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+          }
+        ],
+        "notes": "-相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相當相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相相\n- 2022年7月開放"
+      }
+    }
+  ]
+}

--- a/src/data/mms.ar.json
+++ b/src/data/mms.ar.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "فقط يوم السبت الثاني والأربعاء من كل شهر"
+          }
+        ],
+        "notes": "-لابد أن يكون (برونكس) مقيماً لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الجمعة الثانية والسبت الرابع من كل شهر"
+          }
+        ],
+        "notes": "يجب أن يكون مقيما في بروكلين لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الأربعاء الأول والسبت الثالث من كل شهر"
+          }
+        ],
+        "notes": "- يجب أن يكون ملكة مقيمة لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الخميس الثاني والسبت الرابع من كل شهر"
+          }
+        ],
+        "notes": "- يجب أن يكون من مانهاتن المقيمين لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الأربعاء الأول والسبت الثالث من كل شهر"
+          }
+        ],
+        "notes": "- يجب أن يكون ملكة مقيمة لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الأربعاء الثاني والسبت الرابع من كل شهر"
+          }
+        ],
+        "notes": "- يجب أن يكون من مانهاتن المقيمين لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الثلاثاء الأول والسبت الثالث من كل شهر"
+          }
+        ],
+        "notes": "- يجب أن يكون مقيما في جزيرة ستاتن لتلقي الغذاء"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "الأربعاء الثالث والسبت الأول من كل شهر"
+          }
+        ],
+        "notes": "يجب أن يكون مقيما في بروكلين لتلقي الطعام"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "الثلاثاء الرابع والسبت الثاني من كل شهر"
+          }
+        ],
+        "notes": "-لابد أن يكون (برونكس) مقيماً لتلقي الطعام"
+      }
+    }
+  ]
+}

--- a/src/data/mms.bn.json
+++ b/src/data/mms.bn.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে ২ দিন ও ৪ম বুধবার"
+          }
+        ],
+        "notes": "- খাবার পেয়ে নিশ্চয়ই ব্রক্সের বাসিন্দা"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে শুধুমাত্র ২ম শুক্রবার"
+          }
+        ],
+        "notes": "- খাবার পেতে ব্রুকলিনের বাসিন্দা হতে হবে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে মাত্র ১ দিন ও ৩য় শনিবার"
+          }
+        ],
+        "notes": "- খাবার পাওয়া একজন রানী হতে হবে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে শুধুমাত্র দ্বিতীয় রবিবার"
+          }
+        ],
+        "notes": "- খাবার পাওয়াটা নিশ্চয়ই ম্যানহ্যাটেনের বাসিন্দা"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে মাত্র ১ দিন ও ৩য় শনিবার"
+          }
+        ],
+        "notes": "- খাবার পাওয়া একজন রানী হতে হবে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে শুধুমাত্র ২ দিন ও ৪ম শনিবার"
+          }
+        ],
+        "notes": "- খাবার পাওয়াটা নিশ্চয়ই ম্যানহ্যাটেনের বাসিন্দা"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে ১টা মঙ্গলবার ও ৩য় শনিবার"
+          }
+        ],
+        "notes": "- হতে পারে একটা স্টেটস দ্বীপবাসী খাবার পেতে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "প্রতি মাসে ৩ দিন ও ১ম শনিবার"
+          }
+        ],
+        "notes": "- খাবার পেতে ব্রুকলিনের বাসিন্দা হতে হবে"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "প্রতি মাসে ৪ মঙ্গলবার ও ২য় শনিবার"
+          }
+        ],
+        "notes": "- খাবার পেয়ে নিশ্চয়ই ব্রক্সের বাসিন্দা"
+      }
+    }
+  ]
+}

--- a/src/data/mms.fr.json
+++ b/src/data/mms.fr.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "2ème samedi et 4ème mercredi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident du Bronx pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "2ème vendredi et 4ème samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident de Brooklyn pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "1er mercredi et 3e samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident du Queens pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "2ème jeudi et 4ème samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident Manhattan pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "1er mercredi et 3e samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident du Queens pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "2ème mercredi et 4ème samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident Manhattan pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "1er mardi et 3e samedi de chaque mois"
+          }
+        ],
+        "notes": "- doit être un résident de Staten Island pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "3ème mercredi et 1er samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident de Brooklyn pour recevoir de la nourriture"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "4ème mardi et 2ème samedi de chaque mois"
+          }
+        ],
+        "notes": "- Doit être un résident du Bronx pour recevoir de la nourriture"
+      }
+    }
+  ]
+}

--- a/src/data/mms.pl.json
+++ b/src/data/mms.pl.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko druga sobota i czwarta środa każdego miesiąca"
+          }
+        ],
+        "notes": "- To musi być Bronx"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko drugi piątek i czwarta sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- Musi być mieszkańcem Brooklynu, żeby otrzymać jedzenie"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko 1 środa i 3 sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- Musi być rezydentem Queens, by otrzymać jedzenie"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko 2. czwartek i 4. sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- Musi być mieszkańcem Manhattanu, żeby otrzymać jedzenie"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko 1 środa i 3 sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- Musi być rezydentem Queens, by otrzymać jedzenie"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko 2. środa i 4. sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- Musi być mieszkańcem Manhattanu, żeby otrzymać jedzenie"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko 1 wtorek i 3 sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- musi być rezydentem Staten Island w celu otrzymania żywności"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "Tylko 3 środa i 1 sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- Musi być mieszkańcem Brooklynu, żeby otrzymać jedzenie"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Tylko czwarty wtorek i druga sobota każdego miesiąca"
+          }
+        ],
+        "notes": "- To musi być Bronx"
+      }
+    }
+  ]
+}

--- a/src/data/mms.ru.json
+++ b/src/data/mms.ru.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 2-я суббота и 4-я среда каждого месяца"
+          }
+        ],
+        "notes": "Должен быть резидентом Бронкса, чтобы получать еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 2-я пятница и 4-я суббота каждого месяца"
+          }
+        ],
+        "notes": "- Должно быть, житель Бруклина получает еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 1-я среда и 3-я суббота каждого месяца"
+          }
+        ],
+        "notes": "Должен быть резидентом Квинса, чтобы получать еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 2-й четверг и 4-я суббота каждого месяца"
+          }
+        ],
+        "notes": "Должен быть жителем Манхэттена, чтобы получать еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 1-я среда и 3-я суббота каждого месяца"
+          }
+        ],
+        "notes": "Должен быть резидентом Квинса, чтобы получать еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 2-я среда и 4-я суббота каждого месяца"
+          }
+        ],
+        "notes": "Должен быть жителем Манхэттена, чтобы получать еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 1-й вторник и 3-я суббота каждого месяца"
+          }
+        ],
+        "notes": "- должен быть резидентом Статен-Айленда для приема пищи"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "Только 3-я среда и 1-я суббота каждого месяца"
+          }
+        ],
+        "notes": "- Должно быть, житель Бруклина получает еду"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "Только 4-й вторник и 2-я суббота каждого месяца"
+          }
+        ],
+        "notes": "Должен быть резидентом Бронкса, чтобы получать еду"
+      }
+    }
+  ]
+}

--- a/src/data/mms.ur.json
+++ b/src/data/mms.ur.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کے صرف 2 شوال اور 4 ربیع الاول کو ہی کہتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک گرامی رہائشی ہونا چاہئے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کے صرف 2 محرم اور 4 شوال ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے بروکلن کا رہائشی ہونا ضروری ہے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کا صرف 1 واں اور 3 واں ہفتے"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک ملکہ ہونا چاہئے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کے صرف 2 شوال اور 4 شوال ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک مینہٹن رہائشی ہونا چاہئے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کا صرف 1 واں اور 3 واں ہفتے"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک ملکہ ہونا چاہئے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کے صرف 2 ربیع الاول 4ھ اور 4 شوال ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک مینہٹن رہائشی ہونا چاہئے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کے صرف 1 محرم اور 3 شوال ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک اسٹیٹن جزیرہ ہونا ہوگا"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "ہر مہینے صرف 3 ربیع الاول اور 1 شوال ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے بروکلن کا رہائشی ہونا ضروری ہے"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "ہر مہینے کے صرف 4 محرم اور 2 شوال ہوتے ہیں۔"
+          }
+        ],
+        "notes": "- کھانا حاصل کرنے کے لئے ایک گرامی رہائشی ہونا چاہئے"
+      }
+    }
+  ]
+}

--- a/src/data/mms.zh-Hans.json
+++ b/src/data/mms.zh-Hans.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月的第2个星期六和第4个星期三"
+          }
+        ],
+        "notes": "- 一定是布朗克斯居民接受食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月只有第2个星期五和第4个星期六"
+          }
+        ],
+        "notes": "- 一定是布鲁克林居民接受食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月的第1个星期三和第3个星期六"
+          }
+        ],
+        "notes": "- 必须是皇后区的居民才能得到食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月的第2个星期四和第4个星期六"
+          }
+        ],
+        "notes": "- 一定是曼哈顿居民接受食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月的第1个星期三和第3个星期六"
+          }
+        ],
+        "notes": "- 必须是皇后区的居民才能得到食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月的第2个星期三和第4个星期六"
+          }
+        ],
+        "notes": "- 一定是曼哈顿居民接受食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月第1个星期二和第3个星期六"
+          }
+        ],
+        "notes": "- 必须是岛居民才能得到食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "每个月的第3个星期三和第1个星期六"
+          }
+        ],
+        "notes": "- 一定是布鲁克林居民接受食物"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "每个月的第4个星期二和第2个星期六"
+          }
+        ],
+        "notes": "- 一定是布朗克斯居民接受食物"
+      }
+    }
+  ]
+}

--- a/src/data/mms.zh-Hant.json
+++ b/src/data/mms.zh-Hant.json
@@ -1,0 +1,338 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92025045584433,
+          40.82167210786891
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Melrose",
+        "streetAddress": "286 E 156th St, at the Classic Center",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10451",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92025045584433,
+            40.82167210786891
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月第二星期六和第四星期三"
+          }
+        ],
+        "notes": "- 一定是布朗克斯住地去取取食物了"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.01912045298224,
+          40.64859633888526
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Sunset Park",
+        "streetAddress": "City Harvest Food Rescue Center, 52nd St and 1st Avenue",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11232",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.01912045298224,
+            40.64859633888526
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月的第2周五和第4周六"
+          }
+        ],
+        "notes": "-想吃就去布魯克林住地了"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94461675532463,
+          40.75572388187865
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Queensbridge",
+        "streetAddress": "Basketball court directly behind the Jacob A. Riis Neighborhood Settlement House at 40-07 Vernon Boulevard",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11101",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94461675532463,
+            40.75572388187865
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月一和三週六"
+          }
+        ],
+        "notes": "有入住入住入住入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入出入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入出入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.9418728744004,
+          40.83101156812198
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Prince Hall",
+        "streetAddress": "Prince Hall Masonic Temple, 454 W 155th St, near the corner of St. Nicholas Avenue",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10032",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.9418728744004,
+            40.83101156812198
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月第二星期四和第四星期六了"
+          }
+        ],
+        "notes": "有入住曼哈頓的人才有入住"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.93326110863056,
+          40.77275790484195
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Astoria",
+        "streetAddress": "Basketball court off of Astoria Boulevard, in the Astoria Houses",
+        "addressLocality": "Queens",
+        "addressRegion": "NY",
+        "postalCode": "11102",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.93326110863056,
+            40.77275790484195
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月一和三週六"
+          }
+        ],
+        "notes": "有入住入住入住入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入出入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入出入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入入"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.92396613706121,
+          40.860276796509666
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Washington Heights/Inwood",
+        "streetAddress": "Nagle Ave & 10th Ave on Dyckman St",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "postalCode": "10034",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.92396613706121,
+            40.860276796509666
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月的第2周三和第4周六"
+          }
+        ],
+        "notes": "有入住曼哈頓的人才有入住"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.081849,
+          40.621053
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Stapleton",
+        "streetAddress": "Corner of Warren St. (Cheryl White) and Hill St.",
+        "addressLocality": "Staten Island",
+        "addressRegion": "NY",
+        "postalCode": "10304",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -74.081849,
+            40.621053
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月一 二 三 二 三 星期六"
+          }
+        ],
+        "notes": "有吃吃吃吃吃吃吃吃吃吃吃吃吃活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活活"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.94612087257494,
+          40.696197243224255
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, Bed Stuy",
+        "streetAddress": "Handball court of the Tompkins Houses on Myrtle Avenue, between Throop and Tompkins Avenues",
+        "addressLocality": "Brooklyn",
+        "addressRegion": "NY",
+        "postalCode": "11206",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.94612087257494,
+            40.696197243224255
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "13:30",
+            "notes": "就每個月的第3周三和 第1周六"
+          }
+        ],
+        "notes": "-想吃就去布魯克林住地了"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.90975084005572,
+          40.81520313463588
+        ]
+      },
+      "properties": {
+        "name": "City Harvest Mobile Market, St. Mary's",
+        "streetAddress": "Parking Lot Adjacent to 595 Trinity Ave",
+        "addressLocality": "Bronx",
+        "addressRegion": "NY",
+        "postalCode": "10455",
+        "geolocation": {
+          "type": "Point",
+          "coordinates": [
+            -73.90975084005572,
+            40.81520313463588
+          ]
+        },
+        "status": "open",
+        "addressCountry": "US",
+        "hours": [
+          {
+            "days": [
+              null
+            ],
+            "timeStart": "9:30",
+            "timeEnd": "11:30",
+            "notes": "就每個月的第4个星期二和第2个星期六"
+          }
+        ],
+        "notes": "- 一定是布朗克斯住地去取取食物了"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds `cpds.<lang>.json` and `mms.<lang>.json` for the 8 new languages (`ar`, `bn`, `fr`, `pl`, `ru`, `ur`, `zh-Hans`, `zh-Hant`). Existing `es` / `ko` files are left untouched.

## What's translated
Only `properties.notes` and `properties.hours[].notes`. Names, addresses, postal codes, and geographic references stay in English — same pattern as the existing `es` / `ko` files.

Translations produced via LibreTranslate batch API. **Machine quality — needs native-speaker review before real launch.**

## App.tsx
Imports the new files and adds them to `mmsByLang` / `cpdsByLang`. Anything missing still falls back to English at the read sites (`|| mmsByLang.en`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)