### PR TITLE
Cache-bust R2 pantry fetches per session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import type {MapRef} from 'react-map-gl/maplibre';
 
 import {ZoomButtons} from './ZoomButtons';
 import {Renderer} from './data/Renderer';
-import {logToServer} from './logging';
+import {logToServer, SESSION_ID} from './logging';
 import {
   useEffect,
   useMemo,
@@ -304,7 +304,12 @@ export const App = () => {
     };
 
     const fetchLang = async (targetLang: string) => {
-      const res = await fetch(`${import.meta.env.VITE_DATA_URL}/pantries.open.${targetLang}.json`);
+      // Cache-bust per session: same URL for the tab's lifetime, fresh on new tab.
+      // Insurance against edge-cache poisoning while still letting the browser
+      // HTTP cache handle subsequent renders within the session.
+      const res = await fetch(
+        `${import.meta.env.VITE_DATA_URL}/pantries.open.${targetLang}.json?v=${SESSION_ID}`
+      );
       if(!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = await res.json();
       return Array.isArray(body) ? body : body.data;


### PR DESCRIPTION
## Summary
Append `?v=<SESSION_ID>` to the R2 pantry fetches. Each tab hits R2 origin once for its data; the browser HTTP cache handles subsequent renders within the same session.

## Motivation
Edge-cache poisoning incident: Cloudflare cached the **pre-CORS** response for `feeds/pantries.open.<lang>.json` before the bucket-level CORS policy was added. Every browser hitting the plain URL got the stale cached copy without the `Access-Control-Allow-Origin` header, producing:

> Cross-Origin Request Blocked ... (Reason: CORS header 'Access-Control-Allow-Origin' missing). Status code: 200.

Once the bucket CORS was fixed, the cached entries didn't refresh — the origin response has the header, but Cloudflare's edge kept serving the stale one. Purging the cache would be the "proper" fix (still worth doing), but this app-side change makes the map resilient to that class of issue going forward without abandoning caching entirely.

## Trade-off
Session-scoped busting = one origin hit per tab, then browser cache for the tab lifetime. Alternatives considered:
- Per-load bust (`?v=Date.now()`) — bypasses edge cache on every reload; wasteful
- Per-dump-interval bust — matches the R2 upload cadence but ties client behavior to a magic number

## Test plan
- [ ] `yarn dev` in a hard-reloaded browser tab loads the map with pantries showing
- [ ] Opening in a new incognito tab succeeds even before the Cloudflare edge cache would expire

🤖 Generated with [Claude Code](https://claude.com/claude-code)