### PR TITLE
Log OS family with every server log call

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -3,8 +3,43 @@ const DEBUG = import.meta.env.VITE_DEBUG === 'true';
 // Session ID generated once per page load, kept in memory only
 export const SESSION_ID = crypto.randomUUID();
 
+type OSFamily = 'iOS' | 'Android' | 'Windows' | 'macOS' | 'Linux' | 'Other';
+
+// Broad OS family only — never the full user agent. Matches what the privacy
+// policy says we collect. Kept as a string constant per page load so every
+// log call sees the same value without re-parsing.
+export const OS_FAMILY: OSFamily = detectOSFamily();
+
+function detectOSFamily(): OSFamily {
+  // Prefer navigator.userAgentData when available (client hints, less spoof-prone
+  // in modern Chromium). Cast because TS lib.dom doesn't include it yet.
+  const uaData = (navigator as any).userAgentData as {platform?: string} | undefined;
+  const platform = (uaData?.platform || '').toLowerCase();
+  if (platform) {
+    if (platform.includes('android')) return 'Android';
+    if (platform === 'ios' || platform === 'ipados') return 'iOS';
+    if (platform.includes('mac')) return 'macOS';
+    if (platform.includes('windows')) return 'Windows';
+    if (platform.includes('linux') || platform.includes('chrome os')) return 'Linux';
+  }
+
+  const ua = navigator.userAgent || '';
+  if (/android/i.test(ua)) return 'Android';
+  // iOS check before macOS: iPad Safari now sets "Macintosh" in UA. Use a
+  // touch-based heuristic to catch iPadOS masquerading as macOS.
+  if (/iphone|ipad|ipod/i.test(ua)) return 'iOS';
+  if (/macintosh/i.test(ua)) {
+    // iPadOS 13+ sends Macintosh UA but still exposes touch points.
+    if ((navigator as any).maxTouchPoints > 1) return 'iOS';
+    return 'macOS';
+  }
+  if (/windows/i.test(ua)) return 'Windows';
+  if (/linux|cros/i.test(ua)) return 'Linux';
+  return 'Other';
+}
+
 export const logToServer = (endpoint: string, payload: Record<string, any>) => {
-  const enriched = {...payload, sessionId: SESSION_ID};
+  const enriched = {...payload, sessionId: SESSION_ID, osFamily: OS_FAMILY};
   if (DEBUG) {
     console.log(`[DEBUG] ${endpoint}`, enriched);
     return;


### PR DESCRIPTION
## Summary
Attaches `osFamily` to every `logToServer` payload alongside the existing `sessionId`. The privacy policy already discloses this; the code now actually sends it.

## Detection
- Prefers `navigator.userAgentData.platform` (client hints — less spoof-prone in modern Chromium).
- Falls back to `navigator.userAgent` parsing.
- iPadOS quirk covered: iPad Safari sets a Macintosh UA, so disambiguate via `navigator.maxTouchPoints > 1`.
- Returns one of `iOS` / `Android` / `Windows` / `macOS` / `Linux` / `Other`. Never the full user agent — matches exactly what the privacy policy discloses.

## Test plan
- [ ] Load the map, click a feature, watch a `POST /log-feature-click` in the Network tab. Payload includes `osFamily`.
- [ ] Same on iOS Safari, Android Chrome, macOS Safari, Windows Chrome. Each reports the expected family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)