### PR TITLE
Send classified geocode payload instead of raw address

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import type {MapRef} from 'react-map-gl/maplibre';
 import {ZoomButtons} from './ZoomButtons';
 import {Renderer} from './data/Renderer';
 import {logToServer, SESSION_ID} from './logging';
+import {classifyResult} from './geocode-classify';
 import {
   useEffect,
   useMemo,
@@ -137,8 +138,9 @@ const GeocoderWrapper: React.FC<{
       if(modal){
         modal.current?.dismiss();
       }
-      logGeocode(result, i18n.language);
+      logGeocode(results, i18n.language);
     }}
+    onNoResult={() => logNoResult(i18n.language)}
     helperText={t('geocoder.helperText')}
   />
 };
@@ -186,11 +188,24 @@ const LayerTogglesModal = () => {
   </IonModal>;
 }
 
-const logGeocode = (result: google.maps.GeocoderResult, language: string) => {
+const logGeocode = (results: google.maps.GeocoderResult[], language: string) => {
+  logToServer('/log-geocode', {...classifyResult(results), language});
+};
+
+// Fires when Google returns ZERO_RESULTS. Sends the "user searched for
+// something and found nothing" signal without a coord or raw text.
+const logNoResult = (language: string) => {
   logToServer('/log-geocode', {
-    address: result.formatted_address,
-    lat: result.geometry.location.lat(),
-    lng: result.geometry.location.lng(),
+    searchType: 'unknown',
+    resultBucket: 'NONE',
+    resolvedCity: null,
+    resolvedRegion: null,
+    resolvedBorough: null,
+    resolvedCountry: null,
+    resolvedLocationType: null,
+    lat: null,
+    lng: null,
+    resultsFound: false,
     language,
   });
 };

--- a/src/geocode-classify.ts
+++ b/src/geocode-classify.ts
@@ -1,0 +1,93 @@
+// Deriving the fields the backend wants from a Google GeocoderResult,
+// without ever sending the raw typed text or free-form formatted address.
+
+// Priority list for picking a single searchType from Google's `types` array.
+// Ordered specific → general; first match wins. Anything Google returns that
+// isn't in this list falls through to 'unknown'.
+const SEARCH_TYPE_PRIORITY = [
+  'street_address', 'premise', 'subpremise',
+  'intersection',
+  'postal_code',
+  'route',
+  'point_of_interest', 'establishment', 'airport', 'park', 'natural_feature',
+  'neighborhood',
+  'sublocality_level_5', 'sublocality_level_4', 'sublocality_level_3',
+  'sublocality_level_2', 'sublocality_level_1', 'sublocality',
+  'locality',
+  'colloquial_area',
+  'administrative_area_level_2', 'administrative_area_level_1',
+  'country',
+];
+
+export type ResultBucket = 'NONE' | 'UNIQUE' | 'AMBIGUOUS';
+
+export interface GeocodePayload {
+  searchType: string;
+  resultBucket: ResultBucket;
+  resolvedCity: string | null;
+  resolvedRegion: string | null;
+  resolvedBorough: string | null;
+  resolvedCountry: string | null;
+  resolvedLocationType: string | null;
+  lat: number | null;
+  lng: number | null;
+  resultsFound: boolean;
+}
+
+export function pickSearchType(types: string[] | undefined): string {
+  if (!types) return 'unknown';
+  for (const t of SEARCH_TYPE_PRIORITY) {
+    if (types.includes(t)) return t;
+  }
+  return types[0] || 'unknown';
+}
+
+export function bucketResults(count: number): ResultBucket {
+  if (count === 0) return 'NONE';
+  if (count === 1) return 'UNIQUE';
+  return 'AMBIGUOUS';
+}
+
+type Component = google.maps.GeocoderAddressComponent;
+
+function componentByType(components: Component[] | undefined, type: string, useShortName = false): string | null {
+  if (!components) return null;
+  const hit = components.find((c) => c.types.includes(type));
+  if (!hit) return null;
+  return (useShortName ? hit.short_name : hit.long_name) || null;
+}
+
+export function classifyResult(
+  results: google.maps.GeocoderResult[]
+): GeocodePayload {
+  if (!results.length) {
+    return {
+      searchType: 'unknown',
+      resultBucket: 'NONE',
+      resolvedCity: null,
+      resolvedRegion: null,
+      resolvedBorough: null,
+      resolvedCountry: null,
+      resolvedLocationType: null,
+      lat: null,
+      lng: null,
+      resultsFound: false,
+    };
+  }
+
+  const top = results[0];
+  const components = top.address_components;
+
+  return {
+    searchType: pickSearchType(top.types),
+    resultBucket: bucketResults(results.length),
+    resolvedCity: componentByType(components, 'locality'),
+    resolvedRegion: componentByType(components, 'administrative_area_level_1', true),
+    resolvedBorough: componentByType(components, 'sublocality_level_1'),
+    resolvedCountry: componentByType(components, 'country', true),
+    resolvedLocationType: top.geometry?.location_type || null,
+    lat: top.geometry?.location?.lat() ?? null,
+    lng: top.geometry?.location?.lng() ?? null,
+    resultsFound: true,
+  };
+}

--- a/src/map/Geocoder.tsx
+++ b/src/map/Geocoder.tsx
@@ -13,11 +13,15 @@ interface GeocoderProps {
     locality?: string;
   };
   onGeocode: (results: google.maps.GeocoderResult[]) => void;
+  // Fired when the user's query yielded no results (Google returned
+  // ZERO_RESULTS). The map itself doesn't react to this, but the caller
+  // may want to log the miss.
+  onNoResult?: () => void;
   helperText?: string;
   language?: string;
 }
 
-export function Geocoder({apiKey, components, onGeocode, helperText, language}: GeocoderProps) {
+export function Geocoder({apiKey, components, onGeocode, onNoResult, helperText, language}: GeocoderProps) {
   const {isLoaded} = useJsApiLoader({
     googleMapsApiKey: apiKey,
     libraries: LIBRARIES,
@@ -47,10 +51,12 @@ export function Geocoder({apiKey, components, onGeocode, helperText, language}: 
       (results, status) => {
         if (status === 'OK' && results && results.length > 0) {
           onGeocode(results);
+        } else if (status === 'ZERO_RESULTS') {
+          onNoResult?.();
         }
       },
     );
-  }, [components, onGeocode, language]);
+  }, [components, onGeocode, onNoResult, language]);
 
   const {t} = useTranslation();
 


### PR DESCRIPTION
## Summary
Client now derives the search classification from Google's response and sends only the categorized fields — the raw typed text and Google's free-form `formatted_address` never leave the browser. Companion to the backend privacy refresh (separate repo).

## Changes
- **New `src/geocode-classify.ts`**: pure `classifyResult(results)` picks a `searchType` from Google's `types[]` via priority list (specific → general), buckets `results.length` into `NONE` / `UNIQUE` / `AMBIGUOUS`, and extracts `resolvedCity / Region / Borough / Country` + `resolvedLocationType` from `address_components`.
- **`src/map/Geocoder.tsx`**: new optional `onNoResult` prop, fired when Google returns `ZERO_RESULTS`. Lets the caller log "user searched, found nothing" without a coord.
- **`src/App.tsx`**:
  - `logGeocode(results, language)` now sends `classifyResult(results)` (structured, no raw text)
  - New `logNoResult(language)` sends `{resultsFound: false, ...nulls}` on the zero-result path
  - `GeocoderWrapper` wires `onNoResult={() => logNoResult(...)}`
  - `formatted_address` is no longer sent

## Payload shape

**Success**:
```json
{
  "searchType": "street_address", "resultBucket": "UNIQUE",
  "resolvedCity": "New York", "resolvedRegion": "NY",
  "resolvedBorough": "Brooklyn", "resolvedCountry": "US",
  "resolvedLocationType": "ROOFTOP",
  "lat": 40.6782, "lng": -73.9442,
  "resultsFound": true,
  "language": "es", "sessionId": "...", "osFamily": "iOS"
}
```

**Zero results**: same shape with all resolved-fields null, `resultsFound: false`, `lat/lng: null`.

## Depends on
The backend privacy-refresh Cloud Function rewrite ([backend PR forthcoming]) needs to be deployed for the new fields to land in BigQuery correctly. Until then, the old backend receives the new fields and ignores them (no runtime break; just under-populated logs).

## Test plan
- [ ] `yarn dev`, geocode a known address — devtools Network tab shows the classified payload; no `formatted_address` field
- [ ] Search for `212` (returns ZERO_RESULTS) — Network tab shows the zero-result payload with `resultsFound: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)