### PR TITLE
Route staging builds to -staging Cloud Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build --mode live",
+    "build:staging": "tsc && vite build --mode staging",
     "preview": "vite preview --mode live",
     "test.e2e": "cypress run",
     "test.unit": "vitest",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -38,13 +38,18 @@ function detectOSFamily(): OSFamily {
   return 'Other';
 }
 
+// Staging Cloud Functions are named `-staging` (e.g. `log-geocode-staging`)
+// while prod keeps the bare names. Append the suffix when building in
+// staging mode so `--mode staging` builds hit the staging functions.
+const FUNCTION_SUFFIX = import.meta.env.MODE === 'staging' ? '-staging' : '';
+
 export const logToServer = (endpoint: string, payload: Record<string, any>) => {
   const enriched = {...payload, sessionId: SESSION_ID, osFamily: OS_FAMILY};
   if (DEBUG) {
     console.log(`[DEBUG] ${endpoint}`, enriched);
     return;
   }
-  fetch(`${import.meta.env.VITE_LOG_FUNCTION_URL}${endpoint}`, {
+  fetch(`${import.meta.env.VITE_LOG_FUNCTION_URL}${endpoint}${FUNCTION_SUFFIX}`, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(enriched),


### PR DESCRIPTION
## Summary
Staging Cloud Functions are deployed as `log-geocode-staging` and `log-feature-click-staging`. When the client is built with `--mode staging`, append the `-staging` suffix to the endpoint path so those functions get hit; other modes (dev / live / production) keep the bare paths and hit prod.

## Changes
- **`src/logging.ts`**: reads `import.meta.env.MODE`; suffix is empty unless `MODE === 'staging'`. Same `VITE_LOG_FUNCTION_URL` base URL in either case (path routing).
- **`package.json`**: new `build:staging` script (`tsc && vite build --mode staging`) so Netlify's staging branch can build against `.env.staging`.

## Not in this PR
`.env.staging` still has `VITE_DATA_URL=https://nfa-admin.foodmedcenter.org/file-by-filename` (pre-R2). Should be updated to `https://files.cfamhub.org/feeds` before a real staging build, but env files aren't tracked in the repo.

## Test plan
- [ ] `vite build --mode staging` succeeds
- [ ] Deployed staging build's log requests hit `log-geocode-staging` / `log-feature-click-staging` (visible in the Cloud Functions dashboard / Cloud Logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)