### PR TITLE
Fix feature-click log recording lat/lng: 0,0

### DIFF
--- a/src/map/MapView.tsx
+++ b/src/map/MapView.tsx
@@ -120,7 +120,12 @@ export function MapView({controls, mapRef, onMapClick, protomapsApiKey}: MapView
       for (const f of features) {
         const id = f.properties?.id ?? f.id;
         if (id) {
-          lookup.set(String(id), f.properties ?? {});
+          // Keep the real geometry alongside properties so downstream consumers
+          // (Renderer.tsx logging, in particular) can read the feature's
+          // coordinates from `.geolocation`. Previously we stored only
+          // properties, and geojsonify() had already stripped `geolocation`
+          // out, so feature-click logs recorded `lat: 0, lng: 0`.
+          lookup.set(String(id), {...(f.properties ?? {}), geolocation: f.geometry});
         }
       }
     }


### PR DESCRIPTION
## Summary
Every feature-click log row was landing with `lat = 0, lng = 0` in `resourceMap.featureClicks`. Feature IDs were correct but coordinates useless.

## Cause
- `geojsonify()` destructures `geolocation` OUT of the pantry item and uses it as the GeoJSON feature's `.geometry`. Properties no longer contain `geolocation`.
- `MapView`'s `featureLookupRef` stored only `f.properties` — so by the time `Renderer` read `feature.geolocation?.coordinates` to log the click, `.geolocation` was `undefined` and fell back to `[0, 0]`.

## Fix
Store `{...properties, geolocation: f.geometry}` in the lookup so the coordinates travel with the feature. `Renderer` keeps reading `.geolocation.coordinates` and now gets the real values.

## Confirmation
Every row in `resourceMap_staging.featureClicks` (visible via `bq query`) had `lat = 0, lng = 0`. After this change, rows will carry the pantry's actual coordinates.

## Test plan
- [ ] `yarn dev`, click a pantry marker, verify the `POST /log-feature-click` payload's `lat`/`lng` in DevTools Network tab are the pantry's real coords (not 0,0)
- [ ] After staging deploy: new rows in `resourceMap_staging.featureClicks` show real coords

🤖 Generated with [Claude Code](https://claude.com/claude-code)