### PR TITLE
Localize list joiner, dietary values, and time ranges via Intl

### DIFF
--- a/src/data/RendererUtil.tsx
+++ b/src/data/RendererUtil.tsx
@@ -1,31 +1,42 @@
 import type {TFunction} from 'i18next';
 
-const renderList = (arr: any[]) => arr.length < 3 ? arr.join(' and ') : `${arr.slice(0, -1).join(', ')}, and ${arr[arr.length - 1]}`;
+const renderList = (arr: any[], locale: string = 'en') =>
+  new Intl.ListFormat(locale, {style: 'long', type: 'conjunction'}).format(arr.map(String));
 
-function renderTime(timeStr: string, t: TFunction) {
-  if(timeStr === undefined
-     || timeStr === null){
-    return t('renderer.unknown');
-  }
+// Directus enters dietary values as free-text ("halal", "kosher", "baby food").
+// Slug them for i18n lookup; fall back to the raw string when a key is missing
+// so newly-added values still render (untranslated) instead of blowing up.
+const translateDietary = (value: string, t: TFunction) => {
+  const slug = value.trim().toLowerCase()
+    .replace(/\s+(\w)/g, (_, c) => c.toUpperCase());
+  return t(`dietary.${slug}`, {defaultValue: value});
+};
+
+// Parse "hh:mm:ss" into a Date. The date portion is arbitrary — only the
+// time-of-day is used by the formatter — but both endpoints of a range
+// must share the same date so `formatRange` treats them as same-day.
+const parseTime = (timeStr: string): Date => {
   const [hh, mm, ss] = timeStr.split(':').map(Number);
-
   if (hh < 0 || hh > 23 || mm < 0 || mm > 59 || ss < 0 || ss > 59) {
     throw new Error('Invalid time format. Expected hh:mm:ss with valid time values.');
   }
+  const d = new Date(2000, 0, 1);
+  d.setHours(hh, mm, ss || 0, 0);
+  return d;
+};
 
-  const period = hh >= 12 ? t('renderer.pm') : t('renderer.am');
+const formatTimeRange = (startStr: string, endStr: string | null | undefined, t: TFunction, locale: string): string => {
+  const fmt = new Intl.DateTimeFormat(locale, {hour: 'numeric', minute: '2-digit'});
+  const start = parseTime(startStr);
+  if (!endStr) return `${fmt.format(start)} - ${t('renderer.unknown')}`;
+  return fmt.formatRange(start, parseTime(endStr));
+};
 
-  let hours12 = hh % 12;
-  hours12 = hours12 === 0 ? 12 : hours12;
-
-  return `${hours12}:${mm.toString().padStart(2, '0')}${period}`;
-}
-
-const renderHours = (allHours: any[], t: TFunction) => {
+const renderHours = (allHours: any[], t: TFunction, locale: string) => {
   return allHours.map((hours) => {
     const validDays = hours.days ? hours.days.filter((d: any) => d != null) : [];
-    const days = validDays.length > 0 ? renderList(validDays.map((day: string) => t(`days.${day}`))) : '';
-    const time = hours.timeStart ? `${renderTime(hours.timeStart, t)} - ${renderTime(hours.timeEnd, t)}` : t('renderer.allDay');
+    const days = validDays.length > 0 ? renderList(validDays.map((day: string) => t(`days.${day}`)), locale) : '';
+    const time = hours.timeStart ? formatTimeRange(hours.timeStart, hours.timeEnd, t, locale) : t('renderer.allDay');
     const parts = [days, time, hours.notes].filter(Boolean);
     return parts.join('  \n');
   })
@@ -55,7 +66,8 @@ export const render = (data: any, t: TFunction, locale: string = 'en') => {
   let payload = [];
 
   if(data.dietaryAccomodations){
-    payload.push(t('renderer.dietaryAccommodations', {list: `**${renderList(data.dietaryAccomodations)}**`}));
+    const items = data.dietaryAccomodations.map((v: string) => translateDietary(v, t));
+    payload.push(t('renderer.dietaryAccommodations', {list: `**${renderList(items, locale)}**`}));
   }
 
   switch(data.idRequired){
@@ -70,7 +82,7 @@ export const render = (data: any, t: TFunction, locale: string = 'en') => {
   if(data.hours){
     payload.push('---');
     payload.push(t('renderer.hours'));
-    payload.push(renderHours(data.hours, t));
+    payload.push(renderHours(data.hours, t, locale));
   }
 
   if(data.notes){

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "مجهول",
     "allDay": "كل يوم",
-    "am": "AM",
-    "pm": "PM",
     "dietaryAccommodations": "يوفر هذا الموقع طعام **{{list}}**.",
     "idRequired": "**الهوية مطلوبة**",
     "idNotRequired": "**غير مطلوبة**",
@@ -60,5 +58,10 @@
     "copyEmail": "رسالة إلكترونية",
     "copyPhone": "رقم الهاتف",
     "copied": "Copied"
+  },
+  "dietary": {
+    "babyFood": "طعام الأطفال",
+    "halal": "حلال",
+    "kosher": "كوشر"
   }
 }

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "অজানা",
     "allDay": "সারাদিনব্যাপী",
-    "am": "মেগাবাইট",
-    "pm": "পি- জি- পি",
     "dietaryAccommodations": "এই অবস্থানে **{{list}}** খাবার আছে।",
     "idRequired": "**আইডি প্রয়োজন**",
     "idNotRequired": "**আইডি প্রয়োজন নেই**",
@@ -60,5 +58,10 @@
     "copyEmail": "ই-মেইল কপি করুন",
     "copyPhone": "ফোন নম্বর কপি করো",
     "copied": "অনুলিপি করা হয়েছে"
+  },
+  "dietary": {
+    "babyFood": "শিশু খাদ্য",
+    "halal": "হালাল",
+    "kosher": "কোশের"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "unknown",
     "allDay": "All Day",
-    "am": "AM",
-    "pm": "PM",
     "dietaryAccommodations": "This location has **{{list}}** food.",
     "idRequired": "**ID is required**",
     "idNotRequired": "**ID is not required**",
@@ -60,5 +58,10 @@
     "copyEmail": "Copy email",
     "copyPhone": "Copy phone number",
     "copied": "Copied"
+  },
+  "dietary": {
+    "babyFood": "baby food",
+    "halal": "halal",
+    "kosher": "kosher"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "desconocido",
     "allDay": "Todo el día",
-    "am": "AM",
-    "pm": "PM",
     "dietaryAccommodations": "Este lugar tiene comida **{{list}}**.",
     "idRequired": "**Se requiere identificación**",
     "idNotRequired": "**No se requiere identificación**",
@@ -60,5 +58,10 @@
     "copyEmail": "Copiar correo electrónico",
     "copyPhone": "Copiar número de teléfono",
     "copied": "Copiado"
+  },
+  "dietary": {
+    "babyFood": "comida para bebés",
+    "halal": "halal",
+    "kosher": "kosher"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "inconnu",
     "allDay": "Toute la journée",
-    "am": "AM",
-    "pm": "PM",
     "dietaryAccommodations": "Cet endroit propose des aliments **{{list}}**.",
     "idRequired": "**L'identification est requise**",
     "idNotRequired": "**L'ID n'est pas requis**",
@@ -60,5 +58,10 @@
     "copyEmail": "Copier le courriel",
     "copyPhone": "Copier le numéro de téléphone",
     "copied": "Copies"
+  },
+  "dietary": {
+    "babyFood": "nourriture pour bébés",
+    "halal": "halal",
+    "kosher": "casher"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "알 수 없음",
     "allDay": "종일",
-    "am": "오전",
-    "pm": "오후",
     "dietaryAccommodations": "이 장소에는 **{{list}}** 음식이 있습니다.",
     "idRequired": "**신분증이 필요합니다**",
     "idNotRequired": "**신분증이 필요하지 않습니다**",
@@ -60,5 +58,10 @@
     "copyEmail": "이메일 복사",
     "copyPhone": "전화번호 복사",
     "copied": "복사됨"
+  },
+  "dietary": {
+    "babyFood": "이유식",
+    "halal": "할랄",
+    "kosher": "코셔"
   }
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "nieznany",
     "allDay": "Cały dzień",
-    "am": "AM",
-    "pm": "PM",
     "dietaryAccommodations": "To miejsce oferuje jedzenie **{{list}}**.",
     "idRequired": "* * Wymagany jest identyfikator * *",
     "idNotRequired": "* * ID nie jest wymagany * *",
@@ -60,5 +58,10 @@
     "copyEmail": "Kopiuj e- mail",
     "copyPhone": "Kopiuj numer telefonu",
     "copied": "Kopiowane"
+  },
+  "dietary": {
+    "babyFood": "jedzenie dla niemowląt",
+    "halal": "halal",
+    "kosher": "koszerne"
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "неизвестный",
     "allDay": "Весь день",
-    "am": "АМ",
-    "pm": "ПМ",
     "dietaryAccommodations": "В этом месте есть еда **{{list}}**.",
     "idRequired": "**требуется**",
     "idNotRequired": "**не требуется**",
@@ -60,5 +58,10 @@
     "copyEmail": "Копировать электронную почту",
     "copyPhone": "Копия номера телефона",
     "copied": "Копирован"
+  },
+  "dietary": {
+    "babyFood": "детское питание",
+    "halal": "халяль",
+    "kosher": "кошерное"
   }
 }

--- a/src/i18n/locales/ur.json
+++ b/src/i18n/locales/ur.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "نامعلوم",
     "allDay": "دن",
-    "am": "جگہ",
-    "pm": "پی ایم",
     "dietaryAccommodations": "اِس جگہ پر **{{list}}** کھانا موجود ہے۔",
     "idRequired": "غیر قانونی امداد لازمی ہے۔",
     "idNotRequired": "غیر درج ذیل نہیں ہے۔",
@@ -60,5 +58,10 @@
     "copyEmail": "ای میل کاپی کریں",
     "copyPhone": "فون نمبر کاپی کریں",
     "copied": "کوس"
+  },
+  "dietary": {
+    "babyFood": "بچوں کا کھانا",
+    "halal": "حلال",
+    "kosher": "کوشر"
   }
 }

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -23,8 +23,6 @@
   "renderer": {
     "unknown": "不详",
     "allDay": "全天",
-    "am": "上午",
-    "pm": "首相",
     "dietaryAccommodations": "这个地点提供 **{{list}}** 食物。",
     "idRequired": "需要**ID**",
     "idNotRequired": "不需要**ID**",
@@ -60,5 +58,10 @@
     "copyEmail": "复制电子邮件",
     "copyPhone": "复制电话号码",
     "copied": "复制"
+  },
+  "dietary": {
+    "babyFood": "婴儿食品",
+    "halal": "清真",
+    "kosher": "犹太洁食"
   }
 }


### PR DESCRIPTION
## Summary
- `renderList` now uses `Intl.ListFormat` — Arabic "و", Bengali "এবং", French "et", Urdu "اور", etc. instead of the hardcoded English "and" that was showing up in RTL flow
- Dietary values (`halal` / `kosher` / `baby food`) translate through a new `dietary.*` block per locale, with raw-string fallback for future Directus values
- `renderTime` → `formatTimeRange` via `Intl.DateTimeFormat.formatRange` — locale picks 12/24-hour convention and AM/PM marker (Arabic → `1:00–3:00 م`, Korean → `오후 1:00~3:00`)
- Drops the now-dead `renderer.am` / `renderer.pm` keys from all 10 locales

## Test plan
- [ ] Deploy to staging; switch to Arabic and open a pantry with day-range hours (e.g. Mon-Wed 1-3pm)
- [ ] Verify the day joiner reads "الاثنين والثلاثاء والأربعاء" (not "... and ...")
- [ ] Verify time range reads "1:00–3:00 م" (Arabic PM marker, no English)
- [ ] Verify a pantry with `halal` / `kosher` dietary tags renders as "حلال وكوشر"
- [ ] Spot-check French/Russian/Korean for the same three surfaces
- [ ] Verify English still shows "Mon, Tue, and Wed" / "1:00 – 3:00 PM" unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)