### PR TITLE
Harden hours rendering; drop days-less rows; guard NaN times

### DIFF
--- a/src/data/RendererUtil.tsx
+++ b/src/data/RendererUtil.tsx
@@ -12,34 +12,53 @@ const translateDietary = (value: string, t: TFunction) => {
   return t(`dietary.${slug}`, {defaultValue: value});
 };
 
-// Parse "hh:mm:ss" into a Date. The date portion is arbitrary — only the
-// time-of-day is used by the formatter — but both endpoints of a range
-// must share the same date so `formatRange` treats them as same-day.
-const parseTime = (timeStr: string): Date => {
+// Parse "hh:mm:ss" into a Date, or null if the input is malformed.
+// The date portion is arbitrary — only the time-of-day is used by the
+// formatter — but both endpoints of a range must share the same date so
+// `formatRange` treats them as same-day. Return null (not throw) so one
+// bad row in the feed can't crash the whole Renderer.
+const parseTime = (timeStr: string): Date | null => {
   const [hh, mm, ss] = timeStr.split(':').map(Number);
-  if (hh < 0 || hh > 23 || mm < 0 || mm > 59 || ss < 0 || ss > 59) {
-    throw new Error('Invalid time format. Expected hh:mm:ss with valid time values.');
+  if (!Number.isFinite(hh) || !Number.isFinite(mm) ||
+      hh < 0 || hh > 23 || mm < 0 || mm > 59 ||
+      (ss !== undefined && (!Number.isFinite(ss) || ss < 0 || ss > 59))) {
+    return null;
   }
   const d = new Date(2000, 0, 1);
   d.setHours(hh, mm, ss || 0, 0);
   return d;
 };
 
-const formatTimeRange = (startStr: string, endStr: string | null | undefined, t: TFunction, locale: string): string => {
-  const fmt = new Intl.DateTimeFormat(locale, {hour: 'numeric', minute: '2-digit'});
+// Return the locale-formatted "1:00–3:00 PM" range, or null if either
+// endpoint is missing / malformed. Callers treat null as all-day per
+// the data convention: a partial time range is meaningless, so we don't
+// render "1:00 PM – Unknown".
+const formatTimeRange = (startStr: string | null | undefined, endStr: string | null | undefined, locale: string): string | null => {
+  if (!startStr || !endStr) return null;
   const start = parseTime(startStr);
-  if (!endStr) return `${fmt.format(start)} - ${t('renderer.unknown')}`;
-  return fmt.formatRange(start, parseTime(endStr));
+  const end = parseTime(endStr);
+  if (!start || !end) return null;
+  return new Intl.DateTimeFormat(locale, {hour: 'numeric', minute: '2-digit'}).formatRange(start, end);
 };
 
-const renderHours = (allHours: any[], t: TFunction, locale: string) => {
+// A row with no days is meaningless (whether or not times are set) — drop
+// it and warn so the bad row surfaces in the console. A row with days but
+// no times is intentional in the feed to mean "the times are unknown /
+// unspecified"; we render just the days for now (client wants "All Day"
+// eventually, but not yet). A row with both renders both.
+const renderHours = (allHours: any[], t: TFunction, locale: string, pantryName: string) => {
   return allHours.map((hours) => {
     const validDays = hours.days ? hours.days.filter((d: any) => d != null) : [];
-    const days = validDays.length > 0 ? renderList(validDays.map((day: string) => t(`days.${day}`)), locale) : '';
-    const time = hours.timeStart ? formatTimeRange(hours.timeStart, hours.timeEnd, t, locale) : t('renderer.allDay');
+    if (validDays.length === 0) {
+      console.warn(`[hours] dropping row with no days for pantry ${JSON.stringify(pantryName)}:`, hours);
+      return null;
+    }
+    const days = renderList(validDays.map((day: string) => t(`days.${day}`)), locale);
+    const time = formatTimeRange(hours.timeStart, hours.timeEnd, locale);
     const parts = [days, time, hours.notes].filter(Boolean);
     return parts.join('  \n');
   })
+  .filter(Boolean)
   .join('\n\n');
 };
 
@@ -82,9 +101,12 @@ export const render = (data: any, t: TFunction, locale: string = 'en') => {
   }
 
   if(data.hours){
-    payload.push('---');
-    payload.push(t('renderer.hours'));
-    payload.push(renderHours(data.hours, t, locale));
+    const rendered = renderHours(data.hours, t, locale, data.name);
+    if (rendered) {
+      payload.push('---');
+      payload.push(t('renderer.hours'));
+      payload.push(rendered);
+    }
   }
 
   if(data.notes){

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -21,7 +21,6 @@
     "Sa": "أيام السبت"
   },
   "renderer": {
-    "unknown": "مجهول",
     "allDay": "كل يوم",
     "dietaryAccommodations": "يوفر هذا الموقع طعام **{{list}}**.",
     "idRequired": "**الهوية مطلوبة**",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -21,7 +21,6 @@
     "Sa": "শনিবার"
   },
   "renderer": {
-    "unknown": "অজানা",
     "allDay": "সারাদিনব্যাপী",
     "dietaryAccommodations": "এই অবস্থানে **{{list}}** খাবার আছে।",
     "idRequired": "**আইডি প্রয়োজন**",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -21,7 +21,6 @@
     "Sa": "Saturdays"
   },
   "renderer": {
-    "unknown": "unknown",
     "allDay": "All Day",
     "dietaryAccommodations": "This location has **{{list}}** food.",
     "idRequired": "**ID is required**",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -21,7 +21,6 @@
     "Sa": "Sábados"
   },
   "renderer": {
-    "unknown": "desconocido",
     "allDay": "Todo el día",
     "dietaryAccommodations": "Este lugar tiene comida **{{list}}**.",
     "idRequired": "**Se requiere identificación**",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -21,7 +21,6 @@
     "Sa": "Samedis"
   },
   "renderer": {
-    "unknown": "inconnu",
     "allDay": "Toute la journée",
     "dietaryAccommodations": "Cet endroit propose des aliments **{{list}}**.",
     "idRequired": "**L'identification est requise**",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -21,7 +21,6 @@
     "Sa": "토요일"
   },
   "renderer": {
-    "unknown": "알 수 없음",
     "allDay": "종일",
     "dietaryAccommodations": "이 장소에는 **{{list}}** 음식이 있습니다.",
     "idRequired": "**신분증이 필요합니다**",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -21,7 +21,6 @@
     "Sa": "Soboty"
   },
   "renderer": {
-    "unknown": "nieznany",
     "allDay": "Cały dzień",
     "dietaryAccommodations": "To miejsce oferuje jedzenie **{{list}}**.",
     "idRequired": "**Wymagany jest identyfikator**",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -21,7 +21,6 @@
     "Sa": "Суббота"
   },
   "renderer": {
-    "unknown": "неизвестный",
     "allDay": "Весь день",
     "dietaryAccommodations": "В этом месте есть еда **{{list}}**.",
     "idRequired": "**требуется**",

--- a/src/i18n/locales/ur.json
+++ b/src/i18n/locales/ur.json
@@ -21,7 +21,6 @@
     "Sa": "ہفتے"
   },
   "renderer": {
-    "unknown": "نامعلوم",
     "allDay": "دن",
     "dietaryAccommodations": "اِس جگہ پر **{{list}}** کھانا موجود ہے۔",
     "idRequired": "**شناختی کارڈ درکار ہے**",

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -21,7 +21,6 @@
     "Sa": "星期六"
   },
   "renderer": {
-    "unknown": "不详",
     "allDay": "全天",
     "dietaryAccommodations": "这个地点提供 **{{list}}** 食物。",
     "idRequired": "需要**ID**",


### PR DESCRIPTION
## Summary
- **Crash fix**: `parseTime` no longer lets `NaN` slip past its range check (`NaN < 0` is `false`). Previously, a pantry with malformed time data produced an Invalid Date, which made `Intl.DateTimeFormat.formatRange` throw `"date value is not finite"` and crashed the whole feature-detail panel
- **`formatTimeRange`** returns `null` when either endpoint is missing/unparseable, so we no longer render half-ranges like "1:00 PM – Unknown"
- **`renderHours`** drops any row with no `days` and `console.warn`s the pantry name, so bad feed data surfaces in the console. Row-level rules:
  | days | times | behavior |
  |---|---|---|
  | no  | no  | drop + warn |
  | no  | yes | drop + warn |
  | yes | no  | days only |
  | yes | yes | days + range |
- If every row of a pantry drops, the entire Hours section (divider + header) is omitted rather than leaving a naked heading
- Cleans up the now-dead `renderer.unknown` key across all 10 locales

## Test plan
- [ ] Deploy to staging; click the pantry that crashed previously (Lenox Hill area) → no crash, renders reasonably
- [ ] Open browser console → any dropped-row warnings are visible with pantry names for the data team to fix
- [ ] Marymount Manhattan College (221 E 71st St) → hours section no longer shows nonsense; if all its rows lack days, the whole section is omitted
- [ ] Any pantry with valid `days` + `timeStart`/`timeEnd` still renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)