### PR TITLE
Format lastVerified in UTC so US timezones don't see it a day early

### DIFF
--- a/src/data/RendererUtil.tsx
+++ b/src/data/RendererUtil.tsx
@@ -116,10 +116,13 @@ export const render = (data: any, t: TFunction, locale: string = 'en') => {
   }
 
   if(data.lastVerified){
+    // The date portion is UTC-midnight; format in UTC so a US-timezone
+    // viewer doesn't see it pulled back a day (e.g. "2023-01-30" → "Jan 29").
     const humanReadable = new Date(data.lastVerified.split('T')[0]);
     const localeMap: Record<string, string> = {en: 'en-US', es: 'es-ES', ko: 'ko-KR', id: 'id-ID'};
     const formatter = new Intl.DateTimeFormat(localeMap[locale] || locale, {
-      dateStyle: 'medium'
+      dateStyle: 'medium',
+      timeZone: 'UTC',
     });
     payload.push(t('renderer.lastVerified', {date: formatter.format(humanReadable)}));
   }


### PR DESCRIPTION
## Summary
- `data.lastVerified` is a date-only field stored as UTC midnight. `new Date('2023-01-30')` yields UTC midnight, and `Intl.DateTimeFormat` without a `timeZone` formats in the viewer's local timezone — so any US timezone renders "2023-01-30" as "Jan 29, 2023"
- One-line fix: add `timeZone: 'UTC'` to the formatter

## Test plan
- [ ] Deploy to staging; open a pantry whose `lastVerified` is e.g. `2023-01-30T00:00:00Z` → should now render "Jan 30, 2023" in US timezones (previously "Jan 29")

🤖 Generated with [Claude Code](https://claude.com/claude-code)