### PR TITLE
Fix map stuck at initial size + shift-on-click regression

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -413,7 +413,7 @@ export const App = () => {
 	    {!isMobile &&
 	     <IonGrid className='ion-no-padding'>
 	       <IonRow style={{height: '100vh'}}>
-		 <IonCol>
+		 <IonCol style={{overflow: 'hidden'}}>
 		   <MapView
 		     controls={controls.slice(0, 1)}
 		     mapRef={mapRef}
@@ -421,8 +421,13 @@ export const App = () => {
 		     protomapsApiKey={import.meta.env.VITE_PROTOMAPS_API_KEY}
 		   />
 		 </IonCol>
-		 <IonCol>
-		   <div className='ion-padding'>
+		 {/* Right col has fixed layout dimensions; inner scroll container
+		     absorbs any scrollbar so the map col isn't pushed around.
+		     Without this, clicking a marker changes Renderer content →
+		     right-col scrollbar toggles → left-col width shifts →
+		     MapLibre resize → visible map pan. */}
+		 <IonCol style={{height: '100%', overflow: 'hidden'}}>
+		   <div style={{height: '100%', overflowY: 'auto'}} className='ion-padding'>
 		     <LanguageSelector />
 		     <LayerToggles />
 		     <GeocoderWrapper setCenter={setCenter} />

--- a/src/map/MapView.tsx
+++ b/src/map/MapView.tsx
@@ -191,7 +191,6 @@ export function MapView({controls, mapRef, onMapClick, protomapsApiKey}: MapView
         mapStyle={mapStyle}
         onClick={handleClick}
         onZoomEnd={handleZoomEnd}
-        trackResize={false}
         style={{width: '100%', height: '100%'}}
       >
         <MapLayers />


### PR DESCRIPTION
## Summary
- **MapView.tsx** — drop `trackResize={false}` (added in April to hide the shift-on-click symptom). It was also disabling all legitimate resize handling, leaving the map stuck at whatever dimensions it measured on first mount (a tester saw the map render as a small square in the top-left corner)
- **App.tsx** — fix the shift-on-click bug at its root: wrap the right column's content in a fixed-dimension outer + scrollable inner. The scrollbar now lives inside that wrapper, so toggling it doesn't change the IonCol width, so the map IonCol width stays constant, so the ResizeObserver doesn't fire on marker click

## Test plan (verified locally)
- [x] Click a marker → map no longer pans/shifts
- [x] Right column overflows content → scrollbar appears inside the inner wrapper, no horizontal layout change
- [x] Resize browser window → map fills its container correctly

## Deploy plan
Push main → publish (netlify prod), main → staging (netlify staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)